### PR TITLE
Add nested comprehension test

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,4 +7,13 @@ mod tests {
         let result = comp![x * x for x in 0..=10 if x % 2 == 0 if x % 3 == 0].collect::<Vec<_>>();
         assert_eq!(result, vec![0, 36]);
     }
+
+    #[test]
+    fn test_nested_for_if() {
+        let result = comp![(x, y)
+            for x in 0..=3 if x % 2 == 0
+            for y in 0..=3 if y > x]
+            .collect::<Vec<_>>();
+        assert_eq!(result, vec![(0, 1), (0, 2), (0, 3), (2, 3)]);
+    }
 }


### PR DESCRIPTION
## Summary
- support nested comprehension loops
- test nested for-if conditions

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68835a523be08325b764f2832eb488dd